### PR TITLE
Simple and likely temporary fix for #9. Use JMXConnector.CREDENTIALS …

### DIFF
--- a/metrics-sampler-extension-jmx/src/main/java/org/metricssampler/extensions/jmx/JmxConnection.java
+++ b/metrics-sampler-extension-jmx/src/main/java/org/metricssampler/extensions/jmx/JmxConnection.java
@@ -36,8 +36,8 @@ public class JmxConnection {
 		final Map<String, Object> result = new HashMap<>();
 		result.putAll(config.getConnectionProperties());
 		if (config.getUsername() != null) {
-			result.put(Context.SECURITY_PRINCIPAL, config.getUsername());
-			result.put(Context.SECURITY_CREDENTIALS, config.getPassword());
+			String[]  credentials = new String[] {config.getUsername(), config.getPassword()};
+			result.put(JMXConnector.CREDENTIALS, credentials);
 		}
 		result.put(JMXConnectorFactory.PROTOCOL_PROVIDER_PACKAGES, config.getProviderPackages());
 		if (config.hasSocketOptions()) {


### PR DESCRIPTION
Simple fix of authentication issue (#9). Context environment variables are ignored in JMXConnectorFactory.connect, and until it is fixed, this simple fix enables JMX connections with authentication.