### PR TITLE
Permanent fix SSL CREDENTIALS

### DIFF
--- a/metrics-sampler-extension-jmx/src/main/java/org/metricssampler/extensions/jmx/JmxConnection.java
+++ b/metrics-sampler-extension-jmx/src/main/java/org/metricssampler/extensions/jmx/JmxConnection.java
@@ -11,6 +11,7 @@ import javax.management.remote.JMXServiceURL;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import javax.naming.Context;
 
 import static org.apache.commons.io.IOUtils.closeQuietly;
 
@@ -32,12 +33,21 @@ public class JmxConnection {
 
 	private Map<String, Object> constructEnvironment() {
 		final Map<String, Object> result = new HashMap<>();
+
+		if (config.getProviderPackages() != null && config.getProviderPackages().contains("weblogic")) {
+			if (config.getUsername() != null) {
+				result.put(Context.SECURITY_PRINCIPAL, config.getUsername());
+				result.put(Context.SECURITY_CREDENTIALS, config.getPassword());
+				result.put(JMXConnectorFactory.PROTOCOL_PROVIDER_PACKAGES, config.getProviderPackages());
+	    		return result;
+			}	
+		}
+
 		result.putAll(config.getConnectionProperties());
 		if (config.getUsername() != null) {
 			String[]  credentials = new String[] {config.getUsername(), config.getPassword()};
 			result.put(JMXConnector.CREDENTIALS, credentials);
 		}
-		result.put(JMXConnectorFactory.PROTOCOL_PROVIDER_PACKAGES, config.getProviderPackages());
 		if (config.hasSocketOptions()) {
 			final JmxClientSocketFactory sf = new JmxClientSocketFactory(config.getSocketOptions());
 			result.put("com.sun.jndi.rmi.factory.socket", sf);

--- a/metrics-sampler-extension-jmx/src/main/java/org/metricssampler/extensions/jmx/JmxConnection.java
+++ b/metrics-sampler-extension-jmx/src/main/java/org/metricssampler/extensions/jmx/JmxConnection.java
@@ -38,8 +38,11 @@ public class JmxConnection {
 			if (config.getUsername() != null) {
 				result.put(Context.SECURITY_PRINCIPAL, config.getUsername());
 				result.put(Context.SECURITY_CREDENTIALS, config.getPassword());
+				// This is something for enabling weblogic support. http://download.oracle.com/docs/cd/E13222_01/wls/docs90/jmx/accessWLS.
+		                // You'd set this to: weblogic.management.remote
 				result.put(JMXConnectorFactory.PROTOCOL_PROVIDER_PACKAGES, config.getProviderPackages());
-	    		return result;
+	    			
+				return result;
 			}	
 		}
 


### PR DESCRIPTION
Temporary code changes done to fix SSL issue in PR wasn't proper.: https://github.com/dimovelev/metrics-sampler/pull/10/files

This PR fixes how the credentials are used as per PROTOCOL_PROVIDER_PACKAGES passed by jmx.remote.protocol.provider.packages. 
Ref: This is something for enabling weblogic support. http://download.oracle.com/docs/cd/E13222_01/wls/docs90/jmx/accessWLS. You'd set this to: weblogic.management.remote

Ex: https://github.com/search?q=PROTOCOL_PROVIDER_PACKAGES+weblogic&type=code 

